### PR TITLE
Update to Confluent 3.x

### DIFF
--- a/schema_change.sql
+++ b/schema_change.sql
@@ -1,3 +1,4 @@
+USE demo;
 ALTER TABLE users DROP COLUMN name;
 INSERT INTO users (email, department) VALUES ('charlie@abc.com', 'sales');
 INSERT INTO users (email, department) VALUES ('daniel@abc.com', 'engineering');

--- a/update_users.sql
+++ b/update_users.sql
@@ -1,2 +1,3 @@
+USE demo;
 UPDATE users SET email = 'alice@def.com', modified = CURRENT_TIMESTAMP WHERE name='alice';
 UPDATE users SET email = 'bob@ghi.com', modified = CURRENT_TIMESTAMP WHERE name='bob';

--- a/vagrant/deb.sh
+++ b/vagrant/deb.sh
@@ -76,14 +76,14 @@ popd
 pushd /opt/
 if [ ! -e confluent ]; then
     pushd /tmp/vagrant-downloads
-    if [ ! -e confluent-2.0.0-2.11.7.tar.gz ]; then
-        wget http://packages.confluent.io/archive/2.0/confluent-2.0.0-2.11.7.tar.gz
+    if [ ! -e confluent-3.0.1-2.11.tar.gz ]; then
+        wget http://packages.confluent.io/archive/3.0/confluent-3.0.1-2.11.tar.gz
     fi
     popd
 
-    tar xvzf /tmp/vagrant-downloads/confluent-2.0.0-2.11.7.tar.gz
+    tar xvzf /tmp/vagrant-downloads/confluent-3.0.1-2.11.tar.gz
 fi
-ln -s /opt/confluent-2.0.0 /opt/confluent
+ln -s /opt/confluent-3.0.1 /opt/confluent
 popd
 
 # Copy .profile and change owner to vagrant


### PR DESCRIPTION
After following this [blog post](http://www.confluent.io/blog/how-to-build-a-scalable-etl-pipeline-with-kafka-connect/), I had some issues loading another MySQL database into Hive with Kafka Connect (I saw an NPE when using AvroEncoder).  Updating to 3.0.1 fixed the issue.
